### PR TITLE
Added Support for bash completion in ubuntu

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,17 @@
+if(process.platform=='linux'){
+
+var sys = require('util');
+var exec = require('child_process').exec;
+var child;
+
+child = exec("cp src/qeda /etc/bash_completion.d/qeda", function (error, stdout, stderr) {
+  console.log('stdout: ' + stdout);
+  console.log('stderr: ' + stderr);
+  if (error !== null) {
+    console.log('exec error: ' + error);
+  }
+});
+
+}
+
+

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "library"
   ],
   "author": "Noviga",
+  "contributors": [
+    "Filippo Savi <filssavi@gmail.com>"
+  ],
   "homepage": "http://qeda.org",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "prepublish": "coffee -o lib -c src/",
+    "install": "cp src/qeda /etc/bash_completion.d/qeda",
     "postpublish": "rm -rf lib"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "prepublish": "coffee -o lib -c src/",
-    "install": "cp src/qeda /etc/bash_completion.d/qeda",
+    "install": "node install.js",
     "postpublish": "rm -rf lib"
   },
   "devDependencies": {

--- a/src/installScript.sh
+++ b/src/installScript.sh
@@ -1,0 +1,1 @@
+cp src/qeda /etc/bash_completion.d/qeda

--- a/src/qeda
+++ b/src/qeda
@@ -1,0 +1,15 @@
+_qeda() 
+{
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    #
+    #  The basic options we'll complete.
+    #
+    opts="--help --verbose --version reset add load power ground config generage test"
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))  
+    return 0
+}
+complete -F _qeda qeda


### PR DESCRIPTION
I have added a rudimentary support for bash autocompletion to the qeda utility, right now it works only with top level commands, and not for their options (the configs to change the design rules for example are not completed) since the documentation seemed a bit incomplete (correct me if I'm wrong) and having autocomplete show only some of the possible comands is quite annoing I think

I' dont know well npm and the js language, to have autocompletion work the only thing needed is to copy the file src/qeda (it has to be named like the command for bash to recognize it) in the /etc/bash_completion.d/ folder, and I've done it through the install script hook, on my test VM (clean lubuntu)  I had do add the --unsafe-perm flag for it to run without warnings, that said I don't know if it's a problem with my modification or with the environement since the same warning was shown also for one of the other scripts
