### PR TITLE
JEDEC MS-001 outline: fix leadHeight

### DIFF
--- a/share/outline/jedec/ms-001.yaml
+++ b/share/outline/jedec/ms-001.yaml
@@ -1,13 +1,24 @@
+# dual inline plastic family (R-PDIP-T) .300 inch row spacing
+# dimensions from https://www.jedec.org/system/files/docs/Ms-001d.pdf
 pattern: DIP
 units: inches
 
+# dimension: e
 pitch: 0.1
+# dimension: E1
 bodyWidth: 0.24-0.28
+# dimension: A
 height: 0.21
+# dimension: b
 leadWidth: 0.014-0.022
+# dimension: L
 leadLength: 0.115-0.15
-leadHeight: 0.008-0.01
+# dimension: c
+leadHeight: 0.008-0.014
+# dimension: E
 leadSpan: 0.3-0.325
+# bodyLength dimension: D
+# leadCount dimension: N
 
 AA:
   bodyLength: 0.735-0.775


### PR DESCRIPTION
maximum leadHeight dimension c for JEDEC MS-001 outline is higher
source document: https://www.jedec.org/system/files/docs/Ms-001d.pdf
comments about the dimensions have also been added