### PR TITLE
JEDEC MS-013 outline: add tabWidth and tabLength tolerances

### DIFF
--- a/share/outline/jedec/ms-013.yaml
+++ b/share/outline/jedec/ms-013.yaml
@@ -1,10 +1,21 @@
+# very thin profile, plastic small output family, 1.27 mm pitch, 7.50mm body width (B1R-PDSO/SOP/SOIC)
+# dimensions from https://www.jedec.org/system/files/docs/MS-013F.pdf
 pattern: SOIC
+units: mm
 
+# dimension: E1
 bodyWidth: 7.4-7.6
+# dimension: L
 leadLength: 0.4-1.27
+# dimension: E
 leadSpan: 9.97-10.63
+# dimension: b
 leadWidth: 0.31-0.51
+# dimension: e
 pitch: 1.27
+# bodyLength dimension: D
+# height dimension: A
+# leadCount dimension: N
 
 AA:
   bodyLength: 10.1-10.5
@@ -36,44 +47,47 @@ AF:
   height: 2.65
   leadCount: 14
 
+# tabWidth dimension: E2
+# tabLength dimension: D1
+
 BA:
   bodyLength: 10.1-10.5
   height: 2.5
   leadCount: 16
-  tabWidth: 2
-  tabLength: 3
+  tabWidth: 1.85-2.15
+  tabLength: 2.85-3.15
 
 BB:
   bodyLength: 11.35-11.75
   height: 2.5
   leadCount: 18
-  tabWidth: 2
-  tabLength: 3
+  tabWidth: 1.85-2.15
+  tabLength: 2.85-3.15
 
 BC:
   bodyLength: 12.6-13
   height: 2.5
   leadCount: 20
-  tabWidth: 2
-  tabLength: 3
+  tabWidth: 1.85-2.15
+  tabLength: 2.85-3.15
 
 BD:
   bodyLength: 15.2-15.6
   height: 2.5
   leadCount: 24
-  tabWidth: 2
-  tabLength: 3
+  tabWidth: 1.85-2.15
+  tabLength: 2.85-3.15
 
 BE:
   bodyLength: 17.7-18.1
   height: 2.5
   leadCount: 28
-  tabWidth: 2
-  tabLength: 3
+  tabWidth: 1.85-2.15
+  tabLength: 2.85-3.15
 
 BF:
   bodyLength: 8.8-9.2
   height: 2.5
   leadCount: 14
-  tabWidth: 2
-  tabLength: 3
+  tabWidth: 1.85-2.15
+  tabLength: 2.85-3.15


### PR DESCRIPTION
tabWidth dimension E2 and tabLength dimension D1 have tolerance ggg
of 0.15 mm according to JEDEC MS-013 specification
https://www.jedec.org/system/files/docs/MS-013F.pdf
comments about the dimension have also been added