### PR TITLE
fix two-sided pin assignment

### DIFF
--- a/src/symbol/default/common/two-sided.coffee
+++ b/src/symbol/default/common/two-sided.coffee
@@ -7,7 +7,7 @@ module.exports = (symbol, element, icon, leftName = 'L', rightName = 'R') ->
   schematic.showPinNames ?= false
 
   # Add pins if no any
-  unless element.pinGroups.length
+  unless Object.keys(element.pinGroups).length
     element.pins[1] = { name: leftName, number: 1 }
     element.pins[2] = { name: rightName, number: 2 }
     element.pinGroups[leftName] = [1]


### PR DESCRIPTION
In the current version, there is an issue with the two-sided symbol generator. To determine, whether it needs to add the pins L and R, it checks for the length of the pinGroups object. However, since this is an object, there is no length. Instead, the length of keys of the object has to be checked. This PR fixes that.