### PR TITLE
fix variation filtering

### DIFF
--- a/src/qeda-library.coffee
+++ b/src/qeda-library.coffee
@@ -171,7 +171,7 @@ class QedaLibrary
   # Load element description from remote repository
   #
   load: (element, force = false) ->
-    obj = @loadYaml element, force
+    [obj, filterVariation] = @loadYaml element, force
 
     objs = []
     if obj.variations?
@@ -224,7 +224,7 @@ class QedaLibrary
 
     @check obj
 
-    # Load base descrition
+    # Load base description
     if obj.base?
       unless typeof obj.base is 'string' then obj.base = obj.base.toString()
       bases = obj.base.replace(/\s+/g, '').split(',')
@@ -242,7 +242,7 @@ class QedaLibrary
     if element.indexOf('/') isnt -1
       obj.group ?= element.substr(0, element.indexOf('/')).toUpperCase()
 
-    obj
+    [obj, filterVariation]
 
   #
   # Merge two objects


### PR DESCRIPTION
elements can have variations, add documented in
https://doc.qeda.org/core/component/#-variations-
the issue was that when generating, the variation specified when
the element was add (e.g. qeda add element@variation) was ignored.
this change fixes the issue.

WARNING:
when an element has variations, and no variation is specified,
the element is added in all variations.
but when generating, the variations overwrite each other.
no warning is output.
this issue has not been fixed (the generator does not know which
variation is generated to add this information in the file name,
...)