### PR TITLE
custom: add option to draw pads on bottom layer

### DIFF
--- a/src/pattern/default/custom.coffee
+++ b/src/pattern/default/custom.coffee
@@ -69,7 +69,7 @@ copperPads = (pattern, element, suffix = '') ->
       width: housing['padWidth' + suffix]
       height: housing['padHeight' + suffix]
       shape: if padDiameter? then 'circle' else 'rectangle'
-      layer: ['topCopper', 'topMask', 'topPaste']
+      layer: if housing['padBottom' + suffix] then ['bottomCopper', 'bottomMask', 'bottomPaste'] else ['topCopper', 'topMask', 'topPaste']
 
   if housing['padPosition' + suffix]?
     hasPads = true


### PR DESCRIPTION
footprints for edge-mounted parts (mostly connectors) have pads on
top and bottom copper layer.
previously pad were only drawn on the top copper layer.
this change add the housing option "padBottom".
when "padBottom: true" is added to the pad group, the pads are
placed on the bottom layer.