### PR TITLE
geda symbol: add line thickness for print

### DIFF
--- a/src/geda-generator.coffee
+++ b/src/geda-generator.coffee
@@ -185,7 +185,7 @@ class GedaGenerator
             # end pin attributes
             fs.writeSync fd, "}\n"
           when 'poly'
-            fs.writeSync fd, "H 3 0 0 0 -1 -1 0 -1 -1 -1 -1 -1 #{shape.points.length/2+1}\n"
+            fs.writeSync fd, "H 3 5 0 0 -1 -1 0 -1 -1 -1 -1 -1 #{shape.points.length/2+1}\n"
             for i from [0..(shape.points.length-1)]
                if i % 2 == 0
                  fs.writeSync fd, "#{if i == 0 then 'M' else 'L'} #{shape.points[i]} #{shape.points[i+1]}\n"


### PR DESCRIPTION
polygons with line thickness are visible on the screen, but invisible when exporting to pdf.
this change adds a line thickness.