### PR TITLE
add none polarityMark option to configuration

### DIFF
--- a/src/qeda-pattern.coffee
+++ b/src/qeda-pattern.coffee
@@ -168,6 +168,8 @@ class QedaPattern
         y += d/2
 
     switch @settings.polarityMark
+      when 'none'
+        this
       when 'dot'
         r = d/2
         oldLineWidth = @currentLineWidth


### PR DESCRIPTION
allow not adding the dot polarity mark on footprints.
most footprints already have an additional line to mark pin 1, and removing the dot saves space.
set configuration pattern option polarityMark to 'none'.