### PR TITLE
add config option to disable timestamp

### DIFF
--- a/src/kicad-generator.coffee
+++ b/src/kicad-generator.coffee
@@ -22,10 +22,13 @@ class KicadGenerator
     mkdirp.sync "#{dir}/#{@name}.pretty"
     mkdirp.sync "#{dir}/#{@name}.3dshapes"
 
-    now = new Date
-    timestamp = sprintf "%02d/%02d/%d %02d:%02d:%02d",
-      now.getDate(), now.getMonth() + 1, now.getYear() + 1900,
-      now.getHours(), now.getMinutes(), now.getSeconds()
+    if @library.nodate
+      timestamp = "00/00/0000 00:00:00"
+    else
+      now = new Date
+      timestamp = sprintf "%02d/%02d/%d %02d:%02d:%02d",
+        now.getDate(), now.getMonth() + 1, now.getYear() + 1900,
+        now.getHours(), now.getMinutes(), now.getSeconds()
     log.start "KiCad library '#{@name}.lib'"
     fd = fs.openSync "#{dir}/#{@name}.lib", 'w'
     fs.writeSync fd, "EESchema-LIBRARY Version 2.3 Date: #{timestamp}\n"

--- a/src/qeda-library.coffee
+++ b/src/qeda-library.coffee
@@ -21,6 +21,8 @@ class QedaLibrary
     @connection =
       timeout: 5000
 
+    @nodate = false # don't put generated date in library (version control friendly)
+
     @symbol =
       style: 'default' # Options: default, GOST
       gridSize: 2.5 # Grid cell size


### PR DESCRIPTION
qeda added a timestamp in the generated kicad libraries (symbols
and footprint).
this is not very versioning friendly since the files are changed
after generation although no symbols or footprints are.
the kicad library file format specifies a timestamp field.
the @nodate configuration option sets a static timestamp in this
case.