### PR TITLE
Add support for second level variations

### DIFF
--- a/src/qeda-library.coffee
+++ b/src/qeda-library.coffee
@@ -194,6 +194,12 @@ class QedaLibrary
           if modifier?
             if modifier.toLowerCase() is variation then varObj[param] = v # Replace
             delete varObj[k]
+          if typeof v is 'object' and (not Array.isArray v)
+            for k2, v2 of varObj[k]
+              [param, modifier] = k2.replace(/\s+/g, '').split('@')
+              if modifier?
+                if modifier.toLowerCase() is variation then varObj[k][param] = v2 # Replace
+                delete varObj[k][k2]
         objs.push varObj
     else
       objs.push obj
@@ -257,7 +263,9 @@ class QedaLibrary
   #
   mergeObjects: (dest, src) ->
     for k, v of src
-      if typeof v is 'object' and (not Array.isArray v) and dest.hasOwnProperty k
+      if typeof v is 'object' and (not Array.isArray v)
+        if not dest.hasOwnProperty k
+          dest[k] = {}
         @mergeObjects dest[k], v
       else
         dest[k] = v


### PR DESCRIPTION
With this patch, it is possible to partially override e.g. housing parameters per variation. Before, this was only possible by creating a separate housing node for each variation and copying all relevant information into it. This made it very inconvenient to describe e.g. a whole connector family in a single file.

An (incomplete) example of how this can be used:
```
housing:
  rowCount: 1
  rowCount@2: 2
  rowCount@3: 3
```