### PR TITLE
Allow for integer alias strings

### DIFF
--- a/src/qeda-library.coffee
+++ b/src/qeda-library.coffee
@@ -111,7 +111,7 @@ class QedaLibrary
       # Aliases
       aliases = []
       if obj.alias?
-        for alias in obj.alias.replace(/\s+/g, '').split(',')
+        for alias in obj.alias.toString().replace(/\s+/g, '').split(',')
           aliases = aliases.concat(suffixes.map (v) => alias + v)
       if suffixes.length > 1
         aliases = aliases.concat(suffixes[1..].map (v) => name + v)


### PR DESCRIPTION
If an alias string contains only numbers (as can be the case with e.g. Würth Elektronik components), previous logic breaks, as the replace() can only be called on strings. This makes sure that there always is a string.