### PR TITLE
Allow to force hide pinnumbers in two-sided components

### DIFF
--- a/src/symbol/default/common/two-sided.coffee
+++ b/src/symbol/default/common/two-sided.coffee
@@ -48,6 +48,7 @@ module.exports = (symbol, element, icon, leftName = 'L', rightName = 'R') ->
     decorated = (left.length > 1) or (right.length > 1) or (nc?.length)
 
     schematic.showPinNumbers ?= if decorated then true else false
+    if !schematic.showPinNumbers then decorated = false
 
     width = icon.width
     height = icon.height


### PR DESCRIPTION
Without this change, it is only possible to force pinnumbers to be shown, but not to force hiding them.