### PR TITLE
Allow for new and old style pin name negation

### DIFF
--- a/src/geda-generator.coffee
+++ b/src/geda-generator.coffee
@@ -139,8 +139,11 @@ class GedaGenerator
                 angle = 90
                 alignment = 6
             name = shape.name.toString()
-            if name.includes('~') or shape.inverted
-              name = name.replace(/^~/,'').replace(/~$/,'')
+            if name.includes('~')
+              name = name.replace /~{([^}]+)}/g, '\\_$1\\_'
+              name = name.replace /~([^~]+)~/g, '\\_$1\\_'
+              name = name.replace /~([^~]+)/g, '\\_$1\\_'
+            if shape.inverted
               name = "\\_#{name}\\_"
             fs.writeSync fd, "T #{xt} #{yt} 9 8 #{if element.schematic.showPinNames then 1 else 0} 1 #{angle} #{alignment} 1\n"
             fs.writeSync fd, "pinlabel=#{name}\n"

--- a/src/kicad-generator.coffee
+++ b/src/kicad-generator.coffee
@@ -149,6 +149,15 @@ class KicadGenerator
     fs.writeSync fd, ")\n" # module
 
   #
+  # Format pin names for KiCad
+  #
+  _formatPinName: (name) ->
+    formatted = name.replace /~{([^}]+)}/g, '~$1~'
+    if (formatted.match(/~/g) || []).length % 2 == 1
+      formatted += '~'
+    return formatted
+
+  #
   # Write symbol entry to library file
   #
   _generateSymbol: (fd, element) ->
@@ -199,7 +208,7 @@ class KicadGenerator
       for shape in symbol.shapes
         symObj = @_symbolObj shape
         switch symObj.kind
-          when 'pin' then fs.writeSync fd, "X #{symObj.name} #{symObj.number} #{symObj.x} #{symObj.y} #{symObj.length} #{symObj.orientation} #{symObj.fontSize} #{symObj.fontSize} #{i} 1 #{symObj.type}#{symObj.shape}\n"
+          when 'pin' then fs.writeSync fd, "X #{@_formatPinName(symObj.name)} #{symObj.number} #{symObj.x} #{symObj.y} #{symObj.length} #{symObj.orientation} #{symObj.fontSize} #{symObj.fontSize} #{i} 1 #{symObj.type}#{symObj.shape}\n"
           when 'rectangle' then fs.writeSync fd, "S #{symObj.x1} #{symObj.y1} #{symObj.x2} #{symObj.y2} #{i} 1 #{symObj.lineWidth} #{symObj.fillStyle}\n"
           when 'line' then fs.writeSync fd, "P 2 #{i} 1 #{symObj.lineWidth} #{symObj.x1} #{symObj.y1} #{symObj.x2} #{symObj.y2} N\n"
           when 'circle' then fs.writeSync fd, "C #{symObj.x} #{symObj.y} #{symObj.radius} #{i} 1 #{symObj.lineWidth} #{symObj.fillStyle}\n"

--- a/src/kicad6-generator.coffee
+++ b/src/kicad6-generator.coffee
@@ -114,6 +114,14 @@ class Kicad6Generator
     fs.writeSync fd, ")\n" # module
 
   #
+  # Format pin names for KiCad 6
+  #
+  _formatPinName: (name) ->
+    formatted = name.replace /~([^~{}]+)~/g, '~{$1}'
+    formatted = formatted.replace /~([^~{}]+)/g, '~{$1}'
+    return formatted
+
+  #
   # Write symbol file
   #
   _generateSymbol: (fd, element) ->
@@ -261,7 +269,7 @@ class Kicad6Generator
             fs.writeSync fd, "\n"
             fs.writeSync fd, sprintf("      (at #{@f} #{@f} #{symObj.orientation})\n", symObj.x, symObj.y)
             fs.writeSync fd, sprintf("      (length #{@f})\n", symObj.length)
-            fs.writeSync fd, "      (name \"#{symObj.name}\"\n"
+            fs.writeSync fd, "      (name \"#{@_formatPinName(symObj.name)}\"\n"
             fs.writeSync fd, "        (effects (font (size #{symObj.fontSize} #{symObj.fontSize})"
             if symObj.bold then fs.writeSync fd, " bold"
             if symObj.italic then fs.writeSync fd, " italic"

--- a/src/kicad7-generator.coffee
+++ b/src/kicad7-generator.coffee
@@ -114,6 +114,14 @@ class Kicad7Generator
     fs.writeSync fd, ")\n" # module
 
   #
+  # Format pin names for KiCad 7
+  #
+  _formatPinName: (name) ->
+    formatted = name.replace /~([^~{}]+)~/g, '~{$1}'
+    formatted = formatted.replace /~([^~{}]+)/g, '~{$1}'
+    return formatted
+
+  #
   # Write symbol file
   #
   _generateSymbol: (fd, element) ->
@@ -284,7 +292,7 @@ class Kicad7Generator
               fs.writeSync fd, "line"
             fs.writeSync fd, sprintf(" (at #{@f} #{@f} #{symObj.orientation})", symObj.x, symObj.y)
             fs.writeSync fd, sprintf(" (length #{@f})\n", symObj.length)
-            fs.writeSync fd, "        (name \"#{symObj.name}\" (effects (font (size #{symObj.fontSize} #{symObj.fontSize})"
+            fs.writeSync fd, "        (name \"#{@_formatPinName(symObj.name)}\" (effects (font (size #{symObj.fontSize} #{symObj.fontSize})"
             if symObj.bold then fs.writeSync fd, " bold"
             if symObj.italic then fs.writeSync fd, " italic"
             fs.writeSync fd, ")"


### PR DESCRIPTION
With this change, both KiCad old (`~pin~`/`~pin`) and new style (`~{pin}`) pin name negation are understood by QEDA and correctly converted.